### PR TITLE
svelte server

### DIFF
--- a/svelte/src/routes/+layout.svelte
+++ b/svelte/src/routes/+layout.svelte
@@ -3,13 +3,16 @@
 	import '../app.css';
 	import { base } from '$app/paths';
 	import { goto } from '$app/navigation';
-	import { inject } from '@vercel/analytics';
 	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 
 	let { children } = $props();
 
-	onMount(() => {
-		inject();
+	onMount(async () => {
+		if (browser) {
+			const { inject } = await import('@vercel/analytics');
+			inject();
+		}
 	});
 
 	function goToHome() {
@@ -57,8 +60,6 @@
 		align-items: center;
 		padding: 12px;
 	}
-
-
 
 	.back-button {
 		position: fixed;

--- a/svelte/svelte.config.js
+++ b/svelte/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-static';
+import adapter from '@sveltejs/adapter-vercel';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -7,10 +7,7 @@ const config = {
 
   kit: {
     adapter: adapter({
-      pages: '../site/static/app',
-      assets: '../site/static/app',
-      fallback: 'index.html',
-      precompress: false
+      runtime: 'nodejs18.x'
     }),
     paths: {
       base: '/app',

--- a/svelte/vite.config.ts
+++ b/svelte/vite.config.ts
@@ -2,5 +2,10 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	build: {
+		rollupOptions: {
+			external: ['@vercel/analytics']
+		}
+	}
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,25 +1,5 @@
 {
-    "buildCommand": "curl -L https://github.com/gohugoio/hugo/releases/download/v0.144.2/hugo_extended_0.144.2_Linux-64bit.tar.gz | tar -xz && mv hugo /usr/local/bin/ && cd svelte && npm install && npm run build && cd ../site && hugo --gc --minify",
-    "outputDirectory": "site/public",
-    "rewrites": [
-        {
-            "source": "/app/:path*",
-            "destination": "/app/:path*"
-        },
-        {
-            "source": "/(.*)",
-            "destination": "/$1"
-        }
-    ],
-    "headers": [
-        {
-            "source": "/app/(.*)",
-            "headers": [
-                {
-                    "key": "Cache-Control",
-                    "value": "public, max-age=0, must-revalidate"
-                }
-            ]
-        }
-    ]
+    "installCommand": "cd svelte && npm install",
+    "buildCommand": "cd svelte && npm run build",
+    "outputDirectory": "svelte/.vercel/output"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,25 @@
 {
-    "installCommand": "cd svelte && npm install",
-    "buildCommand": "cd svelte && npm run build",
-    "outputDirectory": "svelte/.vercel/output"
+    "buildCommand": "curl -L https://github.com/gohugoio/hugo/releases/download/v0.144.2/hugo_extended_0.144.2_Linux-64bit.tar.gz | tar -xz && mv hugo /usr/local/bin/ && cd svelte && npm install && npm run build && cd ../site && hugo --gc --minify",
+    "outputDirectory": "site/public",
+    "rewrites": [
+        {
+            "source": "/app/:path*",
+            "destination": "/app/:path*"
+        },
+        {
+            "source": "/(.*)",
+            "destination": "/$1"
+        }
+    ],
+    "headers": [
+        {
+            "source": "/app/(.*)",
+            "headers": [
+                {
+                    "key": "Cache-Control",
+                    "value": "public, max-age=0, must-revalidate"
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
try cursor

## Summary by Sourcery

Migrate SvelteKit app to a Node.js server runtime, externalize and lazily load Vercel Analytics on the client.

Enhancements:
- Switch the SvelteKit adapter to use the Node.js18.x runtime instead of static pages.
- Externalize the '@vercel/analytics' package in the Vite build rollup options.
- Dynamically import and inject Vercel Analytics only when running in the browser during onMount.